### PR TITLE
Remove dots and dashs from zipcode and document numbers

### DIFF
--- a/pagarme/customer.py
+++ b/pagarme/customer.py
@@ -8,6 +8,9 @@ class Customer(object):
                  address_street=None, address_neighborhood=None,
                  address_zipcode=None, address_street_number=None,
                  address_complementary=None, phone_ddd=None, phone_number=None):
+
+        address_zipcode = address_zipcode.replace('.', '').replace('-', '') if address_zipcode else None
+        document_number = document_number.replace('.', '').replace('-', '') if document_number else None
         self.data = {
             'name': name,
             'document_number': document_number,


### PR DESCRIPTION
Now when a customer is created with zipcode or document the dots  and dashs are removed as the pagarme's documentation.

I.e.

``` python
'123.456.789-02' => '12345678902'
'12.456-789' => '12456789'
```