### PR TITLE
Add splitRules to constructor 

### DIFF
--- a/pagarme/transaction.py
+++ b/pagarme/transaction.py
@@ -102,8 +102,8 @@ class Transaction(AbstractResource):
             d.update(self.customer.get_anti_fraud_data())
 
         if self.split_rules:
-            for idx, splitRule in enumerate(self.split_rules):
-                for key, value in splitRule.items():
+            for idx, split_rule in enumerate(self.split_rules):
+                for key, value in split_rule.items():
                     new_key = 'split_rules[{idx}][{key}]'.format(key=key,idx=idx)
                     d[new_key] = value     
 

--- a/pagarme/transaction.py
+++ b/pagarme/transaction.py
@@ -22,6 +22,7 @@ class Transaction(AbstractResource):
             metadata={},
             soft_descriptor='',
             customer=None,
+            split_rules=None,
             **kwargs):
 
         self.amount = amount
@@ -36,6 +37,7 @@ class Transaction(AbstractResource):
         self.id = None
         self.data = {}
         self.customer = customer
+        self.split_rules = split_rules
 
         for key, value in kwargs.items():
             self.data[key] = value
@@ -98,6 +100,12 @@ class Transaction(AbstractResource):
 
         if self.customer:
             d.update(self.customer.get_anti_fraud_data())
+
+        if self.split_rules:
+            for idx, splitRule in enumerate(self.split_rules):
+                for key, value in splitRule.items():
+                    new_key = 'split_rules[{idx}][{key}]'.format(key=key,idx=idx)
+                    d[new_key] = value     
 
         return d
 

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -126,7 +126,6 @@ class TransactionTestCase(PagarmeTestCase):
         )
         self.assertIn('customer[phone][ddd]', transaction.get_data())
 
-
     @mock.patch('requests.post', mock.Mock(side_effect=fake_request_fail))
     def test_charge_transaction_with_invalid_split_rules_fails(self):
         transaction = Transaction(
@@ -150,9 +149,7 @@ class TransactionTestCase(PagarmeTestCase):
         )
         with self.assertRaises(PagarmeApiError):
             transaction.charge()
-
-
-       
+ 
     @mock.patch('requests.post', mock.Mock(side_effect=fake_request))  
     def test_charge_transaction_with_valid_split_rules(self):
         transaction = Transaction(
@@ -176,10 +173,3 @@ class TransactionTestCase(PagarmeTestCase):
         )
         transaction.charge()
         self.assertEqual('processing',transaction.status)
-
-
-
-
-
-
-

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -75,7 +75,7 @@ class TransactionTestCase(PagarmeTestCase):
         self.assertIn('any_argument', transaction.get_data())
 
     @mock.patch('requests.post', mock.Mock(side_effect=fake_request))
-    def test_transaction_caputre_later(self):
+    def test_transaction_capture_later(self):
         transaction = Transaction(
             api_key='apikey',
             amount=314,
@@ -86,7 +86,7 @@ class TransactionTestCase(PagarmeTestCase):
         transaction.capture()
 
     @mock.patch('requests.post', mock.Mock(side_effect=fake_request_fail))
-    def test_transaction_caputre_later_wihtout_charger(self):
+    def test_transaction_capture_later_without_charger(self):
         transaction = Transaction(
             api_key='apikey',
             amount=314,
@@ -98,7 +98,7 @@ class TransactionTestCase(PagarmeTestCase):
 
     @mock.patch('requests.get', mock.Mock(side_effect=fake_request))
     @mock.patch('requests.post', mock.Mock(side_effect=fake_request_fail))
-    def test_transaction_caputre_later_fails(self):
+    def test_transaction_capture_later_fails(self):
         transaction = Transaction(api_key='apikey')
         transaction.find_by_id(314)
         with self.assertRaises(PagarmeApiError):
@@ -125,3 +125,61 @@ class TransactionTestCase(PagarmeTestCase):
             customer = customer
         )
         self.assertIn('customer[phone][ddd]', transaction.get_data())
+
+
+    @mock.patch('requests.post', mock.Mock(side_effect=fake_request_fail))
+    def test_charge_transaction_with_invalid_split_rules_fails(self):
+        transaction = Transaction(
+            apikey='apikey',
+            amount=10000,
+            payment_method='boleto',
+            split_rules = [
+                {
+                    "recipient_id":"idrecipient",
+                    "liable":"true",
+                    "charge_processing_fee":"true",
+                    "percentage":"80" 
+                },
+                {
+                    "recipient_id":"idrecipient",
+                    "liable":"true",
+                    "charge_processing_fee":"true",
+                    "percentage":"30"
+                }
+            ]
+        )
+        with self.assertRaises(PagarmeApiError):
+            transaction.charge()
+
+
+       
+    @mock.patch('requests.post', mock.Mock(side_effect=fake_request))  
+    def test_charge_transaction_with_valid_split_rules():
+        transaction = Transaction(
+            apikey='apikey',
+            amount=10000,
+            payment_method='boleto',
+            split_rules = [
+                {
+                    "recipient_id":"idrecipient",
+                    "liable":"true",
+                    "charge_processing_fee":"true",
+                    "percentage":"20"
+                },
+                {
+                    "recipient_id":"idrecipient2",
+                    "liable":"true",
+                    "charge_processing_fee":"true",
+                    "percentage":"80"
+                }
+            ]
+        )
+        transaction.charge()
+        self.assertEqual('processing',transaction.status)
+
+
+
+
+
+
+

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -150,7 +150,7 @@ class TransactionTestCase(PagarmeTestCase):
         with self.assertRaises(PagarmeApiError):
             transaction.charge()
  
-    @mock.patch('requests.post', mock.Mock(side_effect=fake_request))  
+    @mock.patch('requests.post', mock.Mock(side_effect=fake_request))
     def test_charge_transaction_with_valid_split_rules(self):
         transaction = Transaction(
             apikey='apikey',

--- a/tests/transaction_test.py
+++ b/tests/transaction_test.py
@@ -154,7 +154,7 @@ class TransactionTestCase(PagarmeTestCase):
 
        
     @mock.patch('requests.post', mock.Mock(side_effect=fake_request))  
-    def test_charge_transaction_with_valid_split_rules():
+    def test_charge_transaction_with_valid_split_rules(self):
         transaction = Transaction(
             apikey='apikey',
             amount=10000,


### PR DESCRIPTION
It's then easier to handle transaction creation in the client side for the ones that have split.