### PR TITLE
Upgrade deps and tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-ipdb==0.8.1
-mock==1.3.0
-pytest==2.7.2
-pytest-cov==2.1.0
+ipdb==0.10.1
+mock==2.0.0
+pytest==2.9.2
+pytest-cov==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.7.0
-six==1.9.0
+requests==2.10.0
+six==1.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py26,py27,py33,py34
+envlist = py27,py33,py34,py35
 
 [testenv]
-deps=pytest
+deps=-r{toxinidir}/requirements-dev.txt
 commands =
     py.test


### PR DESCRIPTION
- Upgrade dependecies versions;
- Drop python2.6 support;
- Fix tox.ini file, now using requirements-dev for deps;
- Added python3.5 to envlist in tox.ini.