### PR TITLE
Add 'validate_request_signature' with tests

### DIFF
--- a/pagarme/pagarme.py
+++ b/pagarme/pagarme.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 import hashlib
+import hmac
+
 import requests
 
 from .card import Card
@@ -61,6 +63,20 @@ class Pagarme(object):
         code = code.encode('utf-8')
         sha1_hash = hashlib.sha1(code).hexdigest()
         return fingerprint == sha1_hash
+
+    def validate_request_signature(self, payload, signature):
+        hash_method, current_hash = signature.split('=')
+        hash_constructor = hashlib.sha1
+
+        if hash_method != 'sha1':
+            raise NotImplementedError('Hash type not supported yet.')
+
+        generated_hash = hmac.new(
+            self.api_key.encode('utf-8'), payload.encode('utf-8'),
+            hash_constructor
+        ).hexdigest()
+
+        return current_hash == generated_hash
 
     def start_plan(
             self,

--- a/tests/pagarme_test.py
+++ b/tests/pagarme_test.py
@@ -87,6 +87,21 @@ class PagarmeApiTestCase(PagarmeTestCase):
         pagarme = Pagarme(self.api_key)
         self.assertTrue(pagarme.validate_fingerprint(1, '7eaf1eae64ab8d91bcd2c315350a7e9b321808ee'))
 
+    def test_validate_request_signature(self):
+        pagarme = Pagarme(self.api_key)
+        self.assertTrue(pagarme.validate_request_signature(
+            'sampledata=123512536&another=test',
+            'sha1=9496eceeb457c5fe5fdb88aafb0d60ee9f96887d'
+        ))
+
+    def test_validate_request_signature_with_wrong_hash(self):
+        pagarme = Pagarme(self.api_key)
+        with self.assertRaises(NotImplementedError):
+            pagarme.validate_request_signature(
+                'sampledata=123512536&another=test',
+                'md5=9496eceeb457c5fe5fdb88aafb0d60ee9f96887d'
+            )
+
     @mock.patch('requests.post', mock.Mock(side_effect=fake_create_plan))
     def test_create_plan(self):
         pagarme = Pagarme(self.api_key)


### PR DESCRIPTION
Following the way of work of other languages libraries, like PHP, to validate a request from Pagar.me.

Doc ref: https://docs.pagar.me/advanced/#validando-a-origem-de-um-postback