### PR TITLE
Change broken link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ pip install pagarme-python
 
 ## Documentation
 
-* [API Guide](http://pagar.me/docs)
+* [API Guide](https://docs.pagar.me/)
 
 ## Support
 If you have any problem or suggestion please open an issue [here](https://github.com/pagarme/pagarme-python/issues).


### PR DESCRIPTION
Changed the link to Pagar.me's docs.
It was http://pagar.me/docs, returning 404 error.
Changed to https://docs.pagar.me/, right link.