### PR TITLE
Removendo referência de SDK para corrigir de instalação

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
-from pagarme import sdk
 
 __description__ = 'Pagar.me Python'
 __long_description__ = 'Python library for Pagar.me API'
@@ -17,7 +16,7 @@ testing_extras = [
 
 setup(
     name='pagarme-python',
-    version=sdk.VERSION,
+    version='3.3.1',
     author=__author__,
     author_email=__author_email__,
     packages=find_packages(),


### PR DESCRIPTION
Justamente fiz essa Alteração e consegui fazer o build do projeto. Acho que deveriam repensar essa arquitetura. Talvez também fosse interessante tentarem instalar a lib em um projeto Python de verdade antes de fazer o release para evitar a quebradeira.

Por hora estou usando esse meu fork como fonte de instalação da lib até que vcs consigam consertar esse problema. Está funcionando bem para o meu projeto com essas simples alteração.


