### PR TITLE
Feat/remove bulk anticipation routes

### DIFF
--- a/pagarme/bulk_anticipation.py
+++ b/pagarme/bulk_anticipation.py
@@ -1,29 +1,8 @@
 from pagarme.resources import handler_request
 from pagarme.resources.routes import bulk_anticipation_routes
 
-
-def cancel(recipient_id, bulk_anticipation_id):
-    return \
-        handler_request.post(bulk_anticipation_routes.CANCEL_ANTICIPATION.format(recipient_id, bulk_anticipation_id))
-
-
-def confirm(recipient_id, bulk_anticipation_id):
-    return \
-        handler_request.post(bulk_anticipation_routes.CONFIRM_ANTICIPATION.format(recipient_id, bulk_anticipation_id))
-
-
-def create(recipient_id, dictionary):
-    return handler_request.post(bulk_anticipation_routes.BASE_URL.format(recipient_id), dictionary)
-
-
-def delete(recipient_id, bulk_anticipation_id):
-    return \
-        handler_request.delete(bulk_anticipation_routes.DELETE_ANTICIPATION.format(recipient_id, bulk_anticipation_id))
-
-
 def find_all(recipient_id):
     return handler_request.get(bulk_anticipation_routes.GET_ALL_ANTICIPATIONS.format(recipient_id))
-
 
 def limits(recipient_id, dictionary):
     return handler_request.get(bulk_anticipation_routes.GET_ANTICIPATION_LIMITS.format(recipient_id), dictionary)

--- a/pagarme/bulk_anticipation.py
+++ b/pagarme/bulk_anticipation.py
@@ -1,8 +1,19 @@
 from pagarme.resources import handler_request
 from pagarme.resources.routes import bulk_anticipation_routes
 
+
+def cancel(recipient_id, bulk_anticipation_id):
+    return \
+        handler_request.post(bulk_anticipation_routes.CANCEL_ANTICIPATION.format(recipient_id, bulk_anticipation_id))
+
+
+def create(recipient_id, dictionary):
+    return handler_request.post(bulk_anticipation_routes.BASE_URL.format(recipient_id), dictionary)
+
+
 def find_all(recipient_id):
     return handler_request.get(bulk_anticipation_routes.GET_ALL_ANTICIPATIONS.format(recipient_id))
+
 
 def limits(recipient_id, dictionary):
     return handler_request.get(bulk_anticipation_routes.GET_ANTICIPATION_LIMITS.format(recipient_id), dictionary)

--- a/pagarme/resources/routes/bulk_anticipation_routes.py
+++ b/pagarme/resources/routes/bulk_anticipation_routes.py
@@ -2,6 +2,8 @@ from pagarme.resources.routes.recipient_routes import BASE_URL as BASE_RECIPIENT
 
 BASE_URL = BASE_RECIPIENT + '/{0}/bulk_anticipations'
 
+CANCEL_ANTICIPATION = BASE_URL + '/{1}/cancel'
+
 GET_ALL_ANTICIPATIONS = BASE_URL
 
 GET_ANTICIPATION_LIMITS = BASE_URL + '/limits'

--- a/pagarme/resources/routes/bulk_anticipation_routes.py
+++ b/pagarme/resources/routes/bulk_anticipation_routes.py
@@ -2,12 +2,6 @@ from pagarme.resources.routes.recipient_routes import BASE_URL as BASE_RECIPIENT
 
 BASE_URL = BASE_RECIPIENT + '/{0}/bulk_anticipations'
 
-CANCEL_ANTICIPATION = BASE_URL + '/{1}/cancel'
-
-CONFIRM_ANTICIPATION = BASE_URL + '/{1}/confirm'
-
-DELETE_ANTICIPATION = BASE_URL + '/{1}'
-
 GET_ALL_ANTICIPATIONS = BASE_URL
 
 GET_ANTICIPATION_LIMITS = BASE_URL + '/limits'

--- a/tests/bulk_anticipation_test.py
+++ b/tests/bulk_anticipation_test.py
@@ -6,42 +6,6 @@ from tests.resources.dictionaries import recipient_dictionary
 from tests.resources.dictionaries import transaction_dictionary
 
 
-def test_cancel():
-    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
-    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
-    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
-    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
-    bulk_anticipation.confirm(default_recipient_id, _bulk_anticipation['id'])
-    cancel_bulk_anticipation = bulk_anticipation.cancel(default_recipient_id, _bulk_anticipation['id'])
-    assert cancel_bulk_anticipation['status'] == 'canceled'
-
-
-def test_confirm():
-    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
-    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
-    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
-    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
-    confirm_bulk_anticipation = bulk_anticipation.confirm(default_recipient_id, _bulk_anticipation['id'])
-    assert confirm_bulk_anticipation['status'] == 'pending'
-
-
-def test_create():
-    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
-    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
-    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
-    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
-    assert _bulk_anticipation['id'] is not None
-
-
-def test_delete():
-    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
-    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
-    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
-    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
-    delete_bulk_anticiaption = bulk_anticipation.delete(default_recipient_id, _bulk_anticipation['id'])
-    assert delete_bulk_anticiaption is not None
-
-
 def test_find_all():
     transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
     default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT

--- a/tests/bulk_anticipation_test.py
+++ b/tests/bulk_anticipation_test.py
@@ -6,6 +6,42 @@ from tests.resources.dictionaries import recipient_dictionary
 from tests.resources.dictionaries import transaction_dictionary
 
 
+def test_cancel():
+    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
+    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
+    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
+    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
+    bulk_anticipation.confirm(default_recipient_id, _bulk_anticipation['id'])
+    cancel_bulk_anticipation = bulk_anticipation.cancel(default_recipient_id, _bulk_anticipation['id'])
+    assert cancel_bulk_anticipation['status'] == 'canceled'
+
+
+def test_confirm():
+    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
+    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
+    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
+    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
+    confirm_bulk_anticipation = bulk_anticipation.confirm(default_recipient_id, _bulk_anticipation['id'])
+    assert confirm_bulk_anticipation['status'] == 'pending'
+
+
+def test_create():
+    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
+    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
+    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
+    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
+    assert _bulk_anticipation['id'] is not None
+
+
+def test_delete():
+    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
+    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
+    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
+    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
+    delete_bulk_anticiaption = bulk_anticipation.delete(default_recipient_id, _bulk_anticipation['id'])
+    assert delete_bulk_anticiaption is not None
+
+
 def test_find_all():
     transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
     default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT

--- a/tests/bulk_anticipation_test.py
+++ b/tests/bulk_anticipation_test.py
@@ -11,7 +11,6 @@ def test_cancel():
     default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
     recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
     _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
-    bulk_anticipation.confirm(default_recipient_id, _bulk_anticipation['id'])
     cancel_bulk_anticipation = bulk_anticipation.cancel(default_recipient_id, _bulk_anticipation['id'])
     assert cancel_bulk_anticipation['status'] == 'canceled'
 

--- a/tests/bulk_anticipation_test.py
+++ b/tests/bulk_anticipation_test.py
@@ -16,30 +16,12 @@ def test_cancel():
     assert cancel_bulk_anticipation['status'] == 'canceled'
 
 
-def test_confirm():
-    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
-    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
-    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
-    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
-    confirm_bulk_anticipation = bulk_anticipation.confirm(default_recipient_id, _bulk_anticipation['id'])
-    assert confirm_bulk_anticipation['status'] == 'pending'
-
-
 def test_create():
     transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
     default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
     recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
     _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
     assert _bulk_anticipation['id'] is not None
-
-
-def test_delete():
-    transaction.create(transaction_dictionary.VALID_CREDIT_CARD_TRANSACTION)
-    default_recipient_id = transaction_dictionary.DEFAULT_RECIPIENT
-    recipient.update_recipient(default_recipient_id, recipient_dictionary.UPDATE_RECIPIENT)
-    _bulk_anticipation = bulk_anticipation.create(default_recipient_id, bulk_anticipation_dictionary.BULK_ANTICIPATION)
-    delete_bulk_anticiaption = bulk_anticipation.delete(default_recipient_id, _bulk_anticipation['id'])
-    assert delete_bulk_anticiaption is not None
 
 
 def test_find_all():

--- a/tests/resources/dictionaries/bulk_anticipation_dictionary.py
+++ b/tests/resources/dictionaries/bulk_anticipation_dictionary.py
@@ -3,8 +3,7 @@ from tests.resources.pagarme_test import generate_timestamp
 BULK_ANTICIPATION = {
     'payment_date': generate_timestamp(),
     'timeframe': 'start',
-    'requested_amount': '500000',
-    'build': 'true'
+    'requested_amount': '500000'
 }
 
 LIMITS = {


### PR DESCRIPTION
Este PR tem como objetivo:

- Remover as chamdas para:` PUT '/recipients/:recipient_id/bulk_anticipations/:id'`,
`DELETE '/recipients/:recipient_id/bulk_anticipations/:id'` e `POST '/recipients/:recipient_id/bulk_anticipations/:id/confirm'`
- Remover campo  `'build': 'true'`

